### PR TITLE
Mixins revision.

### DIFF
--- a/cdf-core/cdf/js-modules/addIns/selectableTableAddIn.js
+++ b/cdf-core/cdf/js-modules/addIns/selectableTableAddIn.js
@@ -18,35 +18,35 @@ define(['../Dashboard',
         '../lib/jquery',
         '../lib/datatables',
         'css!./selectableTable'],
-    function (Dashboard, Logger, AddIn, $) {
+    function(Dashboard, Logger, AddIn, $) {
 
-
-    var addIn = {
-
-        name: "selectableTable",
+    Dashboard.registerGlobalAddIn("Base", "mixin", new AddIn({
+        name:  "selectableTable",
         label: "Selectable Table",
 
-        implementation: function(tgt, st, options){
-            return function () {
+        implementation: function(target, state, options) {
+            return function() {
 
-
-                this.selectableTable_addInSetting = function (selectionListName, selectAllParamName,
-                                                              updateCountersEventName, selectedCountParamName,
-                                                              totalCountParamName, selectableColIdx) {
-
+                this.selectableTable_addInSetting = function(
+                    selectionListName,
+                    selectAllParamName,
+                    updateCountersEventName,
+                    selectedCountParamName,
+                    totalCountParamName,
+                    selectableColIdx) {
 
                     var myself = this;
+
                     // Defaults for table render:
-
                     // - selectAll inactive
-                    //		Dashboards.setParameter(selectAllParamName,false);
-
+                    //		Dashboards.setParameter(selectAllParamName, false);
+                    //
                     // - reset Total counts:
                     //		selectTable.resetTotalsCount(totalCountParamName);
-
+                    //
                     // - reset Selected counts and clean selection list:
-                    //		selectTable.clearSelection(selectionListName,selectAllParamName,selectedCountParamName);
-                    //		Dashboards.fireChange(updateCountersEventName,$.now());
+                    //		selectTable.clearSelection(selectionListName, selectAllParamName, selectedCountParamName);
+                    //		Dashboards.fireChange(updateCountersEventName, $.now());
 
                     // Select item AddIn
                     var selectOpts = {
@@ -62,27 +62,38 @@ define(['../Dashboard',
                                 cssClass: "selectBox",
                                 selectedCssClass: "selected",
                                 title: "",
-                                action: function (v, st) {
-                                    var list = myself.dashboard.getParameterValue(selectionListName),
-                                        totSelectCount = myself.dashboard.
-                                            getParameterValue(selectedCountParamName),
-                                        isSelectAllActive = myself.dashboard.
-                                            getParameterValue(selectAllParamName),
+                                action: function(v, state) {
+                                    var dash = myself.dashboard,
+                                        list = dash.getParameterValue(selectionListName),
+                                        totSelectCount = dash.getParameterValue(selectedCountParamName),
+                                        isSelectAllActive = dash.getParameterValue(selectAllParamName),
                                         pos = list.indexOf(v);
 
-                                    if (pos === -1) {
+                                    if(pos === -1) {
                                         list.push(v);
-                                        totSelectCount = ( isSelectAllActive ? totSelectCount -= 1 : totSelectCount += 1 );
+                                        if(isSelectAllActive) totSelectCount -= 1; else totSelectCount += 1;
                                     } else {
                                         list.splice(pos, 1);
-                                        totSelectCount = ( isSelectAllActive ? totSelectCount += 1 : totSelectCount -= 1 );
+                                        if(isSelectAllActive) totSelectCount += 1; else totSelectCount -= 1;
                                     }
-                                    $(st.target).find("#" + this.id).toggleClass("selected");
+
+                                    $(state.target).find("#" + this.id).toggleClass("selected");
+
                                     myself.selectableTable_updateSelectAllOnPageStatus("selected", selectableColIdx);
-                                    myself.selectableTable_updateSelectAllVisStatus(selectionListName, selectAllParamName, totalCountParamName);
-                                    myself.dashboard.setParameter(selectedCountParamName, totSelectCount);
-                                    myself.selectableTable_checkAndProcessFullDataSelection(selectionListName, selectAllParamName, selectedCountParamName, totalCountParamName);
-                                    myself.dashboard.fireChange(updateCountersEventName, new Date().getTime());
+                                    myself.selectableTable_updateSelectAllVisStatus(
+                                            selectionListName,
+                                            selectAllParamName,
+                                            totalCountParamName);
+
+                                    dash.setParameter(selectedCountParamName, totSelectCount);
+
+                                    myself.selectableTable_checkAndProcessFullDataSelection(
+                                            selectionListName,
+                                            selectAllParamName,
+                                            selectedCountParamName,
+                                            totalCountParamName);
+
+                                    dash.fireChange(updateCountersEventName, new Date().getTime());
                                 }
                             }
                         ]
@@ -90,146 +101,156 @@ define(['../Dashboard',
                     myself.setAddInOptions("colType", "selectableTable", selectOpts);
                 };
 
-                this.selectableTable_clearSelection = function (selectionListName, selectAllParamName, selectedCountParamName, totalCountParamName) {
+                this.selectableTable_clearSelection = function(selectionListName, selectAllParamName, selectedCountParamName, totalCountParamName) {
                     this.dashboard.setParameter(selectionListName, []);
                     this.selectableTable_resetSelectedCounts(selectAllParamName, selectedCountParamName, totalCountParamName);
                 };
 
-                this.selectableTable_resetSelectedCounts = function (selectAllParamName, selectedCountParamName, totalCountParamName) {
+                this.selectableTable_resetSelectedCounts = function(selectAllParamName, selectedCountParamName, totalCountParamName) {
                     var isSelectAllActive = this.dashboard.getParameterValue(selectAllParamName),
                         totalCount = this.dashboard.getParameterValue(totalCountParamName);
                     this.dashboard.setParameter(selectedCountParamName, (isSelectAllActive ? totalCount : 0));
                 };
 
-                this.selectableTable_resetTotalsCount = function (totalCountParamName) {
+                this.selectableTable_resetTotalsCount = function(totalCountParamName) {
                     this.dashboard.setParameter(totalCountParamName, 0);
                 };
 
-
-                this.selectableTable_getColDataFromRowList = function (colIdx, $rowList) {
-
+                this.selectableTable_getColDataFromRowList = function(colIdx, $rowList) {
                     // Get Array of original dataTable data on specified column,
-                    //		 for a list of jQuery Trs:
-                    var myself = this;
-                    var dataList = _.map($rowList, function (ele, idx) {
-                        return myself.selectableTable_getColDataFromTr(colIdx, ele);
-                    });
-                    return dataList;
+                    //	for a list of jQuery Trs:
+                    return _.map($rowList, function(ele, idx) {
+                            return this.selectableTable_getColDataFromTr(colIdx, ele);
+                        }, this);
                 };
 
-                this.selectableTable_getColDataFromTr = function (colIdx, tr) {
-
+                this.selectableTable_getColDataFromTr = function(colIdx, tr) {
                     // Get original dataTable data on specified column
                     //		 of specified DOM Tr on table:
-                    var $table = $("#" + this.htmlObject).find("table");
-                    var rowIdx = this.selectableTable_getDataTableRowIdxFromTr(tr);
+                    var $table = $("#" + this.htmlObject).find("table"),
+                        rowIdx = this.selectableTable_getDataTableRowIdxFromTr(tr);
                     return $table.dataTable().fnGetData(rowIdx)[colIdx];
                 };
 
-                this.selectableTable_getDataTableRowIdxFromTr = function (tr) {
-
+                this.selectableTable_getDataTableRowIdxFromTr = function(tr) {
                     // Get DataTable row index of specified DOM Tr on table:
                     return $("#" + this.htmlObject).find("table").dataTable().fnGetPosition(tr);
                 };
                 // Data Tables Interface Layer: END
 
 
-                this.selectableTable_getRowsOnPage = function () {
-
+                this.selectableTable_getRowsOnPage = function() {
                     // Get list of jQuery Tr on table's visible page:
                     var $table = $("#" + this.htmlObject).find("table"),
                         $visTrList = $table.find("tbody").find("tr");
                     return $visTrList;
                 };
 
-                this.selectableTable_getSelectedRowsFromRowsList = function ($rowsList, selectedCssClass, selectableColIdx) {
-
+                this.selectableTable_getSelectedRowsFromRowsList = function($rowsList, selectedCssClass, selectableColIdx) {
                     // Get list of jQuery Trs which are selected on larger jQuery Tr list:
                     var $activeBtns = $rowsList.find(".column" + selectableColIdx).find("." + selectedCssClass);
                     return $activeBtns.parents("tr");
                 };
 
                 this.selectableTable_getSelectedRowsOnPage = function (selectedCssClass, selectableColIdx) {
-
                     // Get selected jQuery Tr list on table's visible page:
                     var $rowsList = this.selectableTable_getRowsOnPage();
                     return this.selectableTable_getSelectedRowsFromRowsList($rowsList, selectedCssClass, selectableColIdx);
                 };
 
                 this.selectableTable_checkIfPageSelectionIsFull = function (selectedCssClass, selectableColIdx) {
-                    return (this.selectableTable_getRowsOnPage().length ===
-                    this.selectableTable_getSelectedRowsOnPage(selectedCssClass, selectableColIdx).length);
+                    return this.selectableTable_getRowsOnPage().length ===
+                           this.selectableTable_getSelectedRowsOnPage(selectedCssClass, selectableColIdx).length;
                 };
 
                 this.selectableTable_updateSelectAllOnPageStatus = function (selectedCssClass, selectableColIdx) {
                     var $allOnPageBtnPh = $("#" + this.htmlObject).find(".selectAllOnPageBtnCont"),
                         isPageFullSelection = this.selectableTable_checkIfPageSelectionIsFull(selectedCssClass, selectableColIdx);
 
-                    if (isPageFullSelection) {
+                    if(isPageFullSelection) {
                         $allOnPageBtnPh.addClass("active")
                     } else {
                         $allOnPageBtnPh.removeClass("active")
                     }
                 };
 
-                this.selectableTable_updateSelectAllVisStatus = function (selectionListName, selectAllParamName, totalCountParamName) {
+                this.selectableTable_updateSelectAllVisStatus = function(selectionListName, selectAllParamName, totalCountParamName) {
                     var $allBtnPh = $("#" + this.htmlObject).find(".selectAllBtnCont"),
                         list = this.dashboard.getParameterValue(selectionListName),
                         selectAllStatus = this.dashboard.getParameterValue(selectAllParamName),
                         totalCount = this.dashboard.getParameterValue(totalCountParamName);
 
-                    $allBtnPh.removeClass("empty");
-                    $allBtnPh.removeClass("full");
-                    $allBtnPh.removeClass("mixed");
+                    $allBtnPh
+                        .removeClass("empty")
+                        .removeClass("full")
+                        .removeClass("mixed");
 
-                    if ((list.length === 0 && !selectAllStatus) || (list.length === totalCount && selectAllStatus)) {
+                    if((list.length === 0 && !selectAllStatus) ||
+                       (list.length === totalCount && selectAllStatus)) {
                         $allBtnPh.addClass("empty")
-                    } else if ((list.length === 0 && selectAllStatus) || (list.length === totalCount && !selectAllStatus)) {
-                        $allBtnPh.addClass("full")
+                    } else if((list.length === 0 && selectAllStatus) ||
+                              (list.length === totalCount && !selectAllStatus)) {
+                        $allBtnPh.addClass("full");
                     } else {
                         $allBtnPh.addClass("mixed")
                     }
                 };
 
-                this.selectableTable_checkAndProcessFullDataSelection = function (selectionListName, selectAllParamName, selectedCountParamName, totalCountParamName) {
-
+                this.selectableTable_checkAndProcessFullDataSelection = function(selectionListName, selectAllParamName, selectedCountParamName, totalCountParamName) {
                     var selectionList = this.dashboard.getParameterValue(selectionListName),
                         totalCount = this.dashboard.getParameterValue(totalCountParamName),
                         originalSelectAlStatus = this.dashboard.getParameterValue(selectAllParamName);
 
-                    //check if end of the road was reached:
-                    if (selectionList.length === totalCount) {
-
-                        //toggle selectAll backstage status:
+                    // Check if end of the road was reached
+                    if(selectionList.length === totalCount) {
+                        // Toggle selectAll backstage status
                         this.dashboard.setParameter(selectAllParamName, !originalSelectAlStatus);
 
-                        //clean selection:
+                        // Clean selection
                         this.selectableTable_clearSelection(selectionListName, selectAllParamName, selectedCountParamName, totalCountParamName);
                     }
                 };
 
                 // Selection control panel on table: START
 
-                this.selectableTable_buildSelectionPanelOnTable = function (selectAllParamName, selectionListName, updateCountersEventName, selectedCountParamName, totalCountParamName, selectableColIdx) {
+                this.selectableTable_buildSelectionPanelOnTable = function(
+                        selectAllParamName,
+                        selectionListName,
+                        updateCountersEventName,
+                        selectedCountParamName,
+                        totalCountParamName,
+                        selectableColIdx) {
 
                     // build header selection control panels:
                     var $thead = $("#" + this.htmlObject).find("thead"),
                         $originalTr = $thead.find("tr"),
-                        $selectAllTr = $("<tr/>").addClass("customTr").addClass("selectAll").
-                            appendTo($thead),
-                        $selectAllOnPageTr = $("<tr/>").addClass("customTr").
-                            addClass("selectAllOnPage").appendTo($thead),
-                        $selectAllBtnPh = $("<div/>").addClass("selectAllBtnCont").
-                            toggleClass("active", this.dashboard.getParameterValue(selectAllParamName)),
-                        $selectAllOnPageBtnPh = $("<div/>").addClass("selectAllOnPageBtnCont");
+                        $selectAllTr = $("<tr/>")
+                            .addClass("customTr")
+                            .addClass("selectAll")
+                            .appendTo($thead),
+                        $selectAllOnPageTr = $("<tr/>")
+                            .addClass("customTr")
+                            .addClass("selectAllOnPage")
+                            .appendTo($thead),
+                        $selectAllBtnPh = $("<div/>")
+                            .addClass("selectAllBtnCont")
+                            .toggleClass("active", this.dashboard.getParameterValue(selectAllParamName)),
+                        $selectAllOnPageBtnPh = $("<div/>")
+                            .addClass("selectAllOnPageBtnCont");
 
-                    $.each($originalTr.find("th"), function (idx, th) {
+                    $.each($originalTr.find("th"), function(idx, th) {
                         var $th = $(th),
                             cssClassAttr = $th.attr("class");
-                        $selectAllTr.append($("<td/>").attr("class", cssClassAttr).
-                            removeClass("sorting"));
-                        $selectAllOnPageTr.append($("<td/>").attr("class", cssClassAttr).
-                            removeClass("sorting"));
+
+                        $selectAllTr.append(
+                            $("<td/>")
+                                .attr("class", cssClassAttr)
+                                .removeClass("sorting"));
+
+                        $selectAllOnPageTr.append(
+                            $("<td/>")
+                                .attr("class", cssClassAttr)
+                                .removeClass("sorting"));
                     });
 
                     var $selectAllTds = $selectAllTr.find("td"),
@@ -237,13 +258,21 @@ define(['../Dashboard',
 
                     $($selectAllTds[0]).append($selectAllBtnPh.append($("<button/>")
                         .click(selectAllCallback)));
-                    $($selectAllTds[1]).append($("<div/>").addClass("label").
-                        text("select all"));
 
-                    $($selectAllOnPageTds[0]).append($selectAllOnPageBtnPh.
-                        append($("<button/>").click(selectAllOnPageCallback)));
-                    $($selectAllOnPageTds[1]).append($("<div/>").addClass("label").
-                        text("select all on this page"));
+                    $($selectAllTds[1]).append(
+                        $("<div/>")
+                            .addClass("label")
+                            .text("select all"));
+
+                    $($selectAllOnPageTds[0]).append(
+                        $selectAllOnPageBtnPh.append(
+                            $("<button/>")
+                                .click(selectAllOnPageCallback)));
+
+                    $($selectAllOnPageTds[1]).append(
+                        $("<div/>")
+                            .addClass("label")
+                            .text("select all on this page"));
 
                     // Define selectAll and selectAllOnPage callbacks (sharing variables on scope):
                     var myself = this;
@@ -251,9 +280,8 @@ define(['../Dashboard',
                     function selectAllCallback() {
                         var $ph = $(this).parent(),
                             isSelectAllActive = myself.dashboard.getParameterValue(selectAllParamName),
-                            newSelectAllState = (isSelectAllActive ? false : true),
-                            selectedCssClass = "selected";
-
+                            newSelectAllState = !isSelectAllActive,
+                            selectedCssClass  = "selected";
 
                         myself.dashboard.setParameter(selectionListName, []);
                         myself.dashboard.setParameter(selectAllParamName, newSelectAllState);
@@ -261,26 +289,23 @@ define(['../Dashboard',
 
                         myself.dashboard.fireChange(updateCountersEventName, $.now());
 
-                        if (newSelectAllState) {
-                            myself.selectableTable_getRowsOnPage().find("button").addClass(selectedCssClass);
-                        } else {
-                            myself.selectableTable_getRowsOnPage().find("button").removeClass(selectedCssClass);
-                        }
+                        myself.selectableTable_getRowsOnPage().find("button")
+                            [newSelectAllState ? 'addClass' : 'removeClass'](selectedCssClass);
 
                         myself.selectableTable_updateSelectAllOnPageStatus(selectedCssClass, selectableColIdx);
 
                         // While adding empty, full and mixed css-classes, kept active class implementation
-                        //		in case button toggle status knowledge becomes handy at DOM in a future situation:
+                        //	in case button toggle status knowledge becomes handy at DOM in a future situation.
                         $ph.toggleClass("active");
 
-                        // New implementation of selectAll css class management:
+                        // New implementation of selectAll css class management.
                         myself.selectableTable_updateSelectAllVisStatus(selectionListName, selectAllParamName, totalCountParamName);
                     }
 
                     function selectAllOnPageCallback() {
                         var $ph = $(this).parent(),
                             isSelectAllOnPageActive = $ph.hasClass("active"),
-                        // isSelectAllActive is telling if we're dealing with a negative selection
+                            // isSelectAllActive is telling if we're dealing with a negative selection
                             isSelectAllActive = myself.dashboard.getParameterValue(selectAllParamName),
                             $visRows = myself.selectableTable_getRowsOnPage(),
                             $selectedRows = myself.selectableTable_getSelectedRowsFromRowsList($visRows, "selected", selectableColIdx),
@@ -291,16 +316,17 @@ define(['../Dashboard',
                             selectedTotalCount = myself.dashboard.getParameterValue(selectedCountParamName);
 
                         if (isSelectAllOnPageActive) {
-                            updatedSelectionList = ( isSelectAllActive ?
-                                _.union(selectionList, allOnPageList) :
-                                _.difference(selectionList, allOnPageList) );
+                            updatedSelectionList = isSelectAllActive
+                                ? _.union(selectionList, allOnPageList)
+                                : _.difference(selectionList, allOnPageList);
 
                             $visRows.find(".column" + selectableColIdx).find("button").removeClass("selected");
                             selectionTotalDelta = 0 - $selectedRows.length;
                         } else {
-                            updatedSelectionList = ( isSelectAllActive ?
-                                _.difference(selectionList, allOnPageList) :
-                                _.union(selectionList, allOnPageList) );
+                            updatedSelectionList = isSelectAllActive
+                                ? _.difference(selectionList, allOnPageList)
+                                : _.union(selectionList, allOnPageList);
+
                             $visRows.find(".column" + selectableColIdx).find("button").addClass("selected");
                             selectionTotalDelta = $visRows.length - $selectedRows.length;
                         }
@@ -311,30 +337,29 @@ define(['../Dashboard',
 
                         $ph.toggleClass("active");
                         myself.selectableTable_checkAndProcessFullDataSelection(selectionListName, selectAllParamName, selectedCountParamName, totalCountParamName);
-                        // update check/update selectAll status:
+                        // update check/update selectAll status
                         myself.selectableTable_updateSelectAllVisStatus(selectionListName, selectAllParamName, totalCountParamName);
-
                     }
-
                 };
 
-
-                this.fnDrawCallback = function f(v) {
+                this.fnDrawCallback = function(v) {
                     var selectableColIdx = 0;
                     this.selectableTable_updateSelectAllOnPageStatus("selected", selectableColIdx);
                 }
 
-
-                this.preExecution = function () {
-                    this.selectableTable_addInSetting(options.selectionListName, options.selectAllParamName,
-                        options.updateCountersEventName, options.selectedCountParamName,
-                        options.totalCountParamName, options.selectableColIdx);
+                this.preExecution = function() {
+                    this.selectableTable_addInSetting(
+                        options.selectionListName,
+                        options.selectAllParamName,
+                        options.updateCountersEventName,
+                        options.selectedCountParamName,
+                        options.totalCountParamName,
+                        options.selectableColIdx);
                 };
 
-                this.postFetch = function (data) {
-
+                this.postFetch = function(data) {
                     // Bypass postFetch if empty
-                    if (_.isEmpty(data.metadata) || data.resultset.length === 0) {
+                    if(_.isEmpty(data.metadata) || data.resultset.length === 0) {
                         this.selectableTable_resetTotalsCount(options.totalCountParamName);
                         this.dashboard.fireChange(options.updateCountersEventName, new Date().getTime());
                         this.lastData = data;
@@ -344,7 +369,9 @@ define(['../Dashboard',
                     var intrinsicSelectionCont = this.dashboard.getParameterValue(options.selectionListName).length,
                         isSelectAllActive = this.dashboard.getParameterValue(options.selectAllParamName),
                         totalCount = data.resultset.length,
-                        selectionCount = ( isSelectAllActive ? totalCount - intrinsicSelectionCont : intrinsicSelectionCont );
+                        selectionCount = isSelectAllActive
+                            ? (totalCount - intrinsicSelectionCont)
+                            : intrinsicSelectionCont;
 
                     this.dashboard.setParameter(options.selectedCountParamName, selectionCount);
                     this.dashboard.setParameter(options.totalCountParamName, totalCount);
@@ -353,19 +380,18 @@ define(['../Dashboard',
                     this.lastData = data;
                 };
 
-
-                this.postExecution = function () {
+                this.postExecution = function() {
                     var $table = $("#" + this.htmlObject);
 
-
-                    this.selectableTable_buildSelectionPanelOnTable(options.selectAllParamName,
+                    this.selectableTable_buildSelectionPanelOnTable(
+                        options.selectAllParamName,
                         options.selectionListName,
                         options.updateCountersEventName,
                         options.selectedCountParamName,
                         options.totalCountParamName,
                         options.selectableColIdx);
 
-                    if (_.isEmpty(this.lastData.metadata) || this.lastData.resultset.length === 0) {
+                    if(_.isEmpty(this.lastData.metadata) || this.lastData.resultset.length === 0) {
                         $table.find("thead").addClass("WDhidden");
                     }
 
@@ -373,78 +399,67 @@ define(['../Dashboard',
                     this.selectableTable_updateSelectAllVisStatus(options.selectionListName, options.selectAllParamName, options.totalCountParamName);
                 };
 
-
                 return this;
-            }
+            };
         }
+    }));
 
-    };
-
-    Dashboard.registerGlobalAddIn("Base", "mixin", new AddIn(addIn));
-
-
-
-    var colTypeAddIn = {
-        name: "selectableTable",
+    Dashboard.registerGlobalAddIn("Table", "colType", new AddIn({
+        name:  "selectableTable",
         label: "Table Select",
         defaults: {
-            getSelectedList: function(){
+            getSelectedList: function() {
                 return [];
             },
-            getSelectAllStatus: function(){
+            getSelectAllStatus: function() {
                 return false;
             },
-            buttons:[
+            buttons: [
                 {
                     id: "selectBtn",
                     cssClass: "selectButton",
                     selectedCssClass: "selected",
                     title: "Select",
-                    action: function(v, st) {
+                    action: function(v, state) {
                         Logger.log(v);
                     }
                 }
             ]
         },
 
-        init: function(){
-            $.fn.dataTableExt.oSort[this.name+'-asc'] = $.fn.dataTableExt.oSort['string-asc'];
-            $.fn.dataTableExt.oSort[this.name+'-desc'] = $.fn.dataTableExt.oSort['string-desc'];
+        init: function() {
+            $.fn.dataTableExt.oSort[this.name + '-asc' ] = $.fn.dataTableExt.oSort['string-asc'];
+            $.fn.dataTableExt.oSort[this.name + '-desc'] = $.fn.dataTableExt.oSort['string-desc'];
         },
 
-        implementation: function(tgt, st, opt){
-            var $buttonContainer = $('<div/>').addClass('buttonContainer')
-                .addClass('numButtons-' + opt.buttons.length);
+        implementation: function(target, state, options) {
+            var buttons = options.buttons,
+                $buttonContainer = $('<div/>')
+                    .addClass('buttonContainer')
+                    .addClass('numButtons-' + buttons.length);
 
-            _.each(opt.buttons, function(el,idx){
-                var $button = $("<button/>").attr("id",el.id).addClass(el.cssClass||"")
-                    .text(el.title||"");
+            if(buttons.length) {
+                var valueIndex = options.getSelectedList().indexOf(state.value),
+                    selected   = options.getSelectAllStatus()
+                        ? valueIndex === -1
+                        : valueIndex  >  -1;
 
-                if(opt.getSelectAllStatus() === false){
-                    if (opt.getSelectedList().indexOf(st.value) > -1) {
-                        $button.addClass(el.selectedCssClass);
-                    }
-                } else {
-                    if (opt.getSelectedList().indexOf(st.value) === -1) {
-                        $button.addClass(el.selectedCssClass);
-                    }
-                }
-                $button.click(function(){
-                    if (el.action) {
-                        el.action(st.value, st);
-                    }
+                _.each(buttons, function(el) {
+                    var $button = $("<button/>")
+                            .attr("id", el.id)
+                            .addClass(el.cssClass || "")
+                            .text(el.title || "")
+                            .click(function() {
+                                if(el.action) el.action(state.value, state);
+                            });
+
+                    if(selected) $button.addClass(el.selectedCssClass);
+
+                    $buttonContainer.append($button);
                 });
-                $buttonContainer.append($button);
-            });
-            $(tgt).empty().append($buttonContainer);
+            }
+
+            $(target).empty().append($buttonContainer);
         }
-
-    };
-
-
-
-    Dashboard.registerGlobalAddIn("Table", "colType", new AddIn(colTypeAddIn));
-
-
-
+    }));
 });

--- a/cdf-core/cdf/js-modules/components/BaseComponent.js
+++ b/cdf-core/cdf/js-modules/components/BaseComponent.js
@@ -14,11 +14,16 @@
 define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", "../Logger", "../dashboard/Utils"],
   function(Base, $, _, Backbone, Logger, Utils) {
 
+  var O_hasOwn = Object.prototype.hasOwnProperty,
+      O_getOwn = function(p, dv) {
+          return O_hasOwn.call(this, p) ? this[p] : dv;
+      },
+      undefined; // [DCL] Just because I'm sure some of you would complain!
+
   var BaseComponent = Base.extend(Backbone.Events).extend({
-  
+
     //type : "unknown",
-    extensionPoints: ["preExecution", "postExecution", "preChange", "postChange", "postFetch"],
-    
+
     visible: true,
     isManaged: true,
     timerStart: 0,
@@ -29,73 +34,239 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
     //valueAsId:
     //valuesArray:
     //autoFocus: false,
-  
+
     /**
      * Creates an instance of BaseComponent
      *
      * @constructor
      * @alias module:constructor
      */
-    constructor: function(dashboard, properties) {    
+    constructor: function(dashboard, properties) {
       this.extend(properties);
       this.dashboard = dashboard;
-      
-      if (this.mixins && this.mixins.length > 0) {
-        this.extensionPoints = this.extensionPoints.concat(this._extensionPoints);
-        _.each(this.extensionPoints, function (param, index) {
-            this["mixin" + param] = this[param];
-        }, this);
-        var mixinsLength = this.mixins.length;
-        for (var x = 0; x < mixinsLength; x++) {
-            var mixinDefinition = this.mixins[x];
-            _.each(this.extensionPoints, function (param, index) {
-                delete this[param];
-            }, this);
 
-
-          var impl = this.getAddIn("mixin", mixinDefinition[0]).call(null, this, mixinDefinition[1]);
-            impl.call(this);
-            _.each(this.extensionPoints, function (param, index) {
-                this[param + x] = this[param];
-            }, this);            
-        }
-        _.each(this.extensionPoints, function (param, index) {
-            this._addMixedInExtensionPoint(param, mixinsLength);
-        }, this);                    
-      }
+      if(this.mixins && this.mixins.length > 0) this._addMixins(this.mixins);
     },
-  
-    _addMixedInExtensionPoint : function (extensionPoint, mixinsLength) {
-        this[extensionPoint] = function () {
-            var res;
-            if (this["mixin" + extensionPoint]) {
-                res = this["mixin" + extensionPoint].apply(this, arguments);
-            }    
-            for (var x = 0; x < mixinsLength; x++) {
-                if (this[extensionPoint + x]) {
-                    try {
-                        res = this[extensionPoint + x].apply(this, arguments);
-                    } catch (e) {
-                        Logger.error("Exception while calling component addin " + (x+1) 
-                            + " in component " + this.name + " for phase " 
-                            + extensionPoint + ": " + e);
+
+    /**
+     * Adds the specified mixin definitions to this instance.
+     *
+     * This method is called only once per instance, from its constructor.
+     *
+     * @param {Array.<Array>} mixins The array of mixin definitions.
+     *   Each definition is an array of two positions.
+     *   The first is the name of the mixin.
+     *   The second is the mixin's configuration object.
+     *
+     * @private
+     */
+    _addMixins: function(mixins) {
+        // Sample structure of the methodInfoByName map
+        // <name>: { // @type MethodInfo
+        //     name: extPointName,
+        //     main: mainMethod,
+        //     mixins: [
+        //        {<extPointName>: extPointMethod}
+        //     ]
+        // }
+        var methodInfoByName = {},
+            methodInfos = [],
+            i = -1,
+            L = mixins.length;
+
+        // Index all mixins' methods into methodInfos/methodInfosByName.
+        while(++i < L) addMixin.call(this, mixins[i]);
+
+        // Coordinate methodInfos with more than one implementation.
+        i = -1; L = methodInfos.length;
+        while(++i < L) this._setupMixinMethod(methodInfos[i]);
+
+        function addMixin(mixinDef) {
+            var addInName = mixinDef[0],
+                addInOpts = mixinDef[1],
+                impl = this.getAddIn("mixin", addInName)
+                        .call(/*target:*/null, /*state:*/this, /*options:*/addInOpts),
+                mixin = {};
+
+            // Install the mixin on an auxiliary object.
+            impl.call(mixin);
+
+            // For every own property defined in mixin,
+            // create a methodInfo object in methodInfos.
+            for(var extPointName in mixin) {
+                if(O_hasOwn.call(mixin, extPointName)) {
+                    var extPointValue = mixin[extPointName];
+                    if(!_.isFunction(extPointValue)) {
+                        // Smash (not even checking if it is a function locally...)
+                        this[extPointName] = extPointValue;
+                    } else {
+                        var methodInfo = O_getOwn.call(methodInfoByName, extPointName);
+                        if(!methodInfo) {
+                            methodInfo = methodInfoByName[extPointName] = {
+                                name:   extPointName,
+                                main:   this[extPointName] || null,
+                                mixins: []
+                            };
+                            methodInfos.push(methodInfo);
+                        }
+
+                        methodInfo.mixins.push({
+                            name:   addInName,    // Debug info
+                            method: extPointValue
+                        });
                     }
                 }
             }
+        }
+    },
+
+    /**
+     * Sets up a mixed-in method in this instance given a method information object.
+     *
+     * @param {object} methodInfo The method information object.
+     * @param {string} methodInfo.name The name of the method to create.
+     * @param {function|null} methodInfo.main The main method or <tt>null</tt>, if none.
+     *   The main method is the method that the instance receives from its class prototype,
+     *   and is usually called in a priviledged manner, w.r.t. the other mixed in methods.
+     * @param {Array.<Object>} methodInfo.mixins An array of at least one mixin information object.
+     *   Each object has a property <i>name</i>, with the name of the mixin, for debugging purposes,
+     *   and a property <i>method</i>, with the mixin method.
+     */
+     _setupMixinMethod: function(methodInfo) {
+        var name   = methodInfo.name,
+            main   = methodInfo.main,
+            mixins = methodInfo.mixins,
+            M      = mixins.length,
+            builder;
+
+        if(!main && M === 1) {
+            // This is an own method of a single mixin.
+            // Just copy it; no coordination is necessary.
+            this[name] = mixins[0].method;
+        } else {
+            // Coordination is necessary.
+            builder = this._getMixinMethodBuilder(name);
+            this[name] = builder.call(this, name, main, mixins, M);
+            this[name].displayName = "Component Coordination Method " + name;
+        }
+    },
+
+    /**
+     * Obtains the coordination method-builder method that should be used to
+     * build/create a given method name.
+     *
+     * The default implementation looks up a method named
+     * <tt>"_createMixinMethod_" + name</tt> located in this instance.
+     * If one is not defined,
+     * the default {@link BaseComponent#_createMixinMethodAfterNormal} is returned.
+     *
+     * @param {string} name The name of the method to coordinate.
+     * @return {function} The builder method.
+     * It will be called on the <tt>this</tt> value.
+     *
+     * @protected
+     */
+    _getMixinMethodBuilder: function(name) {
+        return this['_createMixinMethod_' + name] ||
+               this._createMixinMethodAfterNormal;
+    },
+
+    /**
+     * Creates a normal <i>after</i> mixin coordination method,
+     * given the method name, main method and mixins.
+     *
+     * The coordination method first calls the <i>main</i> method, if one exists.
+     * Then, each mixin method is called in the order in which the mixin was added to this object.
+     * If one mixin method throws an error, execution resumes by calling the next mixin method.
+     * The returned result is that of the last mixin method.
+     * The only case in which the main method result is returned is when all mixin methods fail.
+     *
+     * @param {string} name The name of the method being coordinated.
+     * @param {function|null} main The main method, if any, or <tt>null</tt>.
+     * @param {Array.<Object>} mixins An array of at least one mixin information object.
+     *   Each object has a property <i>name</i>, with the name of the mixin, for debugging purposes,
+     *   and a property <i>method</i>, with the mixin method.
+     * @param {number} M The number of elements in argument <i>mixins</i>. At least one.
+     *
+     * @return {function} A coordination method.
+     * @private
+     */
+    _createMixinMethodAfterNormal: function(name, main, mixins, M) {
+        return function normalMethod() {
+            var res, m = -1;
+            if(main) res = main.apply(this, arguments);
+
+            while(++m < M) {
+                try {
+                    res = mixins[m].method.apply(this, arguments);
+                } catch(ex) {
+                    Logger.error(
+                        "Error occurred while calling component addin " + mixins[m].name +
+                        " in component " + this.name +
+                        " for phase "    + name + ": " + ex);
+                }
+            }
+
             return res;
         };
-        
-    
     },
-  
-  
+
+    /**
+     * Coordination method builder for the <i>preExecution</i> method.
+     *
+     * Provides the usual interpretation given to the result value of
+     * a <i>preExecution</i> method to each called method.
+     *
+     * The first method to return a non-<tt>undefined</tt>, yet <i>falsy</i> value
+     * cancels the component's execution and prevents other methods from being called.
+     *
+     * Apart from this special handling,
+     * this method behaves similarly to {@link BaseComponent#_createMixinMethodAfterNormal}.
+     *
+     * @param {string} name The name of the method being coordinated.
+     * @param {function|null} main The main method, if any, or <tt>null</tt>.
+     * @param {Array.<Object>} mixins An array of at least one mixin information object.
+     *   Each object has a property <i>name</i>, with the name of the mixin, for debugging purposes,
+     *   and a property <i>method</i>, with the mixin method.
+     * @param {number} M The number of elements in argument <i>mixins</i>. At least one.
+     *
+     * @return {function} A coordination method.
+     * @private
+     */
+    _createMixinMethod_preExecution: function(name, main, mixins, M) {
+        return function preExecMethod() {
+            var res, m = -1;
+            if(main) {
+                res = main.apply(this, arguments);
+                if(res !== undefined && !res) return false;
+            }
+
+            while(++m < M) {
+                try {
+                    res = mixins[m].method.apply(this, arguments);
+                    if(res !== undefined && !res) return false;
+                } catch(ex) {
+                    Logger.error(
+                        "Error occurred while calling component addin " + mixins[m].name +
+                        " in component " + this.name +
+                        " for phase "    + name + ": " + ex);
+                }
+            }
+
+            return true;
+        };
+    },
+
+    // TODO: Should postExecution be coordinated in before+reverse?
+    // i.e. last mixin first, ..., first mixin, main method last.
+
     placeholder: function(selector) {
       var ho = this.htmlObject;
-      return ho 
+      return ho
         ? $("#" + ho + (selector ? (" " + selector) : ""))
         : $();
     },
-  
+
     focus: function() {
       try {
         this
@@ -103,18 +274,18 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
           .focus();
       } catch(ex) { /* Swallow, maybe hidden. */ }
     },
-  
+
     _doAutoFocus: function() {
       if(this.autoFocus) {
         delete this.autoFocus;
         this.focus();
       }
     },
-  
+
     clear : function() {
       this.placeholder().empty();
     },
-  
+
     copyEvents: function(target,events) {
       _.each(events,function(evt, evtName){
         var e = evt,
@@ -124,7 +295,7 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
         }
       })
     },
-  
+
     clone: function(parameterRemap,componentRemap,htmlRemap) {
       var that, dashboard, callbacks;
       /*
@@ -142,7 +313,7 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
       that.dashboard = this.dashboard = dashboard;
       this._events = callbacks;
       this.copyEvents(that,callbacks);
-  
+
       if(that.parameters) {
         that.parameters = that.parameters.map(function(param){
           if (param[1] in parameterRemap) {
@@ -177,27 +348,44 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
       return that;
     },
 
-    getAddIn: function(slot,addIn) {
+    getAddIn: function(subType, addInName) {
+      // [DCL] Since when can `type` be a function?
       var type = typeof this.type == "function" ? this.type() : this.type;
-      var addInImpl = this.dashboard.getAddIn(type,slot,addIn);
-      if (addInImpl != null) {
-        return addInImpl;
-      }
-      return this.dashboard.getAddIn("Base", slot, addIn);
+
+      return this.dashboard.getAddIn(type,   subType, addInName) ||
+             this.dashboard.getAddIn("Base", subType, addInName);
     },
 
-    hasAddIn: function(slot,addIn) {
+    hasAddIn: function(subType, addInName) {
       var type = typeof this.type == "function" ? this.type() : this.type;
-      var result = this.dashboard.hasAddIn(type,slot,addIn);
-      if (!result)
-        return this.dashboard.hasAddIn("Base",slot,addIn);
+
+      return this.dashboard.hasAddIn(type,   subType, addInName) ||
+             this.dashboard.hasAddIn("Base", subType, addInName);
+    },
+
+    setAddInOptions: function(subType, addIn, options) {
+        var addInOpts   = this.addInOptions  || (this.addInOptions  = {}),
+            subTypeOpts = addInOpts[subType] || (addInOpts[subType] = {});
+
+        subTypeOpts[addIn] = options;
+    },
+
+    getAddInOptions: function(subType, addIn) {
+        var addInOpts, subTypeOpts;
+        return ((addInOpts   = this.addInOptions) &&
+                (subTypeOpts = addInOpts[subType]) &&
+                subTypeOpts[addIn]) || {};
+    },
+
+    setAddInDefaults: function(subType, addIn, defaults) {
+        Logger.log("BaseComponent.setAddInDefaults was removed. You should call setAddInOptions or dashboard.setAddInDefaults");
     },
 
     getValuesArray : function() {
       var jXML;
       if(typeof(this.valuesArray) == 'undefined' || this.valuesArray.length == 0) {
         if(typeof(this.queryDefinition) != 'undefined') {
-  
+
           var vid = (this.queryDefinition.queryType == "sql")?"sql":"none";
           if((this.queryDefinition.queryType == "mdx") && (!this.valueAsId)) {
             vid = "mdx";
@@ -224,7 +412,7 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
           }
           return myArray;
         } else {
-  
+
           //go through parameter array and update values
           var p = new Array(this.parameters?this.parameters.length:0);
           for(var i= 0, len = p.length; i < len; i++) {
@@ -232,7 +420,7 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
             var value = this.parameters[i][1] == "" || this.parameters[i][1] == "NIL" ? this.parameters[i][2] : this.dashboard.getParameterValue(this.parameters[i][1]);
             p[i] = [key,value];
           }
-  
+
           //execute the xaction to populate the selector
           var myself=this;
           if(this.url) {
@@ -254,17 +442,17 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
     },
 
     parseArray : function(jData,includeHeader) {
-  
+
       if(jData === null) {
         return []; //we got an error...
       }
-  
+
       if($(jData).find("CdaExport").size() > 0) {
         return this.parseArrayCda(jData, includeHeader);
       }
-  
+
       var myArray = new Array();
-  
+
       var jHeaders = $(jData).find("COLUMN-HDR-ITEM");
       if(includeHeader && jHeaders.size() > 0) {
         var _a = new Array();
@@ -273,7 +461,7 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
         });
         myArray.push(_a);
       }
-  
+
       var jDetails = $(jData).find("DATA-ROW");
       jDetails.each(function(){
         var _a = new Array();
@@ -282,15 +470,15 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
         });
         myArray.push(_a);
       });
-  
+
       return myArray;
-  
+
     },
 
     parseArrayCda : function(jData,includeHeader) {
       //ToDo: refactor with parseArray?..use as parseArray?..
       var myArray = new Array();
-  
+
       var jHeaders = $(jData).find("ColumnMetaData");
       if(jHeaders.size() > 0){
         if(includeHeader) {//get column names
@@ -301,7 +489,7 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
           myArray.push(_a);
         }
       }
-  
+
       //get contents
       var jDetails = $(jData).find("Row");
       jDetails.each(function() {
@@ -311,66 +499,40 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
         });
         myArray.push(_a);
       });
-  
+
       return myArray;
-  
-    },
-  
-    setAddInDefaults: function(slot,addIn,defaults) {
-      Logger.log("BaseComponent.setAddInDefaults was removed. You should call setAddInOptions or dashboard.setAddInDefaults");
+
     },
 
-    setAddInOptions: function(slot, addIn,options) {
-      if(!this.addInOptions) {
-        this.addInOptions = {};
-      }
-  
-      if(!this.addInOptions[slot]) {
-        this.addInOptions[slot] = {};
-      }
-      this.addInOptions[slot][addIn] = options
-    },
-  
-    getAddInOptions: function(slot,addIn) {
-      var opts = null;
-      try {
-        opts = this.addInOptions[slot][addIn];
-      } catch (e) {
-        /* opts is still null, no problem */
-      }
-      /* opts is falsy if null or undefined */
-      return opts || {};
-    },
-  
     startTimer: function(){
-  
+
       this.timerStart = new Date();
       this.timerSplit = new Date();
-  
+
     },
-  
+
     splitTimer: function() {
-  
+
       // Sanity check, in case this component doesn't follow the correct workflow
       if(this.elapsedSinceStart === -1 || this.elapsedSinceSplit === -1) {
         this.startTimer();
       }
-  
+
       var now = new Date();
-  
+
       this.elapsedSinceStart = now.getTime() - this.timerStart.getTime();
       this.elapsedSinceSplit = now.getTime() - this.timerSplit.getTime();
-  
+
       this.timerSplit = now;
       return this.getTimerInfo();
     },
-  
+
     formatTimeDisplay: function(t) {
       return Math.log(t)/Math.log(10)>=3?Math.round(t/100)/10+"s":t+"ms";
     },
-  
+
     getTimerInfo: function() {
-  
+
         return {
           timerStart: this.timerStart,
           timerSplit: this.timerSplit,
@@ -379,9 +541,9 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
           elapsedSinceSplit: this.elapsedSinceSplit,
           elapsedSinceSplitDesc: this.formatTimeDisplay(this.elapsedSinceSplit)
         }
-  
+
     },
-  
+
     /*
      * This method assigns and returns a unique and somewhat randomish color for
      * this log. The goal is to be able to track cdf lifecycle more easily in
@@ -389,9 +551,9 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
      * and 75 for saturation and between 45 and 80 for value
      *
      */
-  
+
     getLogColor: function() {
-  
+
       if(this.logColor) {
         return this.logColor;
       } else {
@@ -408,19 +570,19 @@ define(["../lib/Base", "../lib/jquery", "../lib/underscore", "../lib/backbone", 
           }
           return hash;
         }
-  
+
         var hash = hashCode(this.name).toString();
         var hueSeed = hash.substr(hash.length-6,2) || 0;
         var saturationSeed = hash.substr(hash.length-2,2) || 0;
         var valueSeed = hash.substr(hash.length-4,2) || 0;
-  
+
         this.logColor = Utils.hsvToRgb(
           360 / 100 * hueSeed,
           75 / 100 * saturationSeed,
           45 + (80 - 45) / 100 * valueSeed);
-        
+
         return this.logColor;
-  
+
       }
     }
   });

--- a/cdf-core/cdf/js-modules/dashboard/Container.js
+++ b/cdf-core/cdf/js-modules/dashboard/Container.js
@@ -171,8 +171,9 @@ define(function () {
 
       var holder = getHolder(type, name, isTry);
 
-      // Can't store as singletons instances with special config params
-      if(config) { isNew = true;  } else
+      // Can't store as singletons, instances that have special config params
+      if(config) { isNew = true;  }
+      else
       if(!isNew) { config = {}; }
 
       return holder ? holder.build(config, isNew) : null;

--- a/cdf-core/cdf/js-modules/dashboard/Dashboard.addIns.js
+++ b/cdf-core/cdf/js-modules/dashboard/Dashboard.addIns.js
@@ -19,13 +19,20 @@ define([
 
 
   var globalAddIns = new Container();
-  
-  function normalizeAddInKey (key, subKey) {
-    if (key.indexOf('Component', key.length - 'Component'.length) !== -1) 
-        key = key.substring(0, key.length - 'Component'.length);  
-    key = key.charAt(0).toUpperCase() + key.substring(1);  
-    if(subKey) { key += "." + subKey; }  
-    return key;    
+
+  // Normalization - Ensure component does not finish with component and capitalize first letter
+  var CompSuffix = 'Component';
+  var CompSuffixLen = CompSuffix.length;
+
+  function normalizeAddInKey(key, subKey) {
+    if(key.indexOf(CompSuffix, key.length - CompSuffixLen) !== -1)
+      key = key.substring(0, key.length - CompSuffixLen);
+
+    key = key.charAt(0).toUpperCase() + key.substring(1);
+
+    if(subKey) { key += "." + subKey; }
+
+    return key;
   }
 
   Dashboard.registerGlobalAddIn = function(type, subType, addIn) {
@@ -34,56 +41,44 @@ define([
       globalAddIns.register(type, name, addIn);
   };
 
-
-
   Dashboard.implement({
-      
-    _initAddIns: function(){
+
+    _initAddIns: function() {
+      // [DCL] This most probably does NOT clone
+      // the way the writer wanted it to...
       this.addIns = Utils.clone(globalAddIns);
     },
-  
-    registerGlobalAddIn : function(type,subType,addIn){
-        Dashboard.registerGlobalAddIn(type, subType, addIn);
+
+    // [DCL] Either it is static or not...
+    registerGlobalAddIn: function(type, subType, addIn) {
+      Dashboard.registerGlobalAddIn(type, subType, addIn);
     },
 
-    registerAddIn : function(type,subType,addIn) {
+    registerAddIn: function(type, subType, addIn) {
       var type = normalizeAddInKey(type, subType),
           name = addIn.getName ? addIn.getName() : null;
       this.addIns.register(type, name, addIn);
     },
-  
 
-    hasAddIn : function(type,subType,addInName){
-      var type = normalizeAddInKey(type, subType);
-      return Boolean(this.addIns && this.addIns.has(type,addInName));
+    hasAddIn: function(type, subType, addInName) {
+      type = normalizeAddInKey(type, subType);
+      return this.addIns.has(type, addInName);
     },
-  
-    getAddIn : function(type,subType,addInName){
-      var type = normalizeAddInKey(type, subType);
-      try {
-        var addIn = this.addIns.get(type, addInName);
-        return addIn;
-      } catch(e) {
-        return null;
-      }
+
+    getAddIn: function(type, subType, addInName) {
+      type = normalizeAddInKey(type, subType);
+      return this.addIns.tryGet(type, addInName);
     },
-  
-    setAddInDefaults : function(type, subType, addInName, defaults) {
+
+    setAddInDefaults: function(type, subType, addInName, defaults) {
       var addIn = this.getAddIn(type, subType, addInName);
-      if(addIn) {
-        addIn.setDefaults(defaults);
-      }
+      if(addIn) addIn.setDefaults(defaults);
     },
-    
-    listAddIns : function(type, subType) {
-    var type = normalizeAddInKey(type, subType);
-      var addInList = [];
-      try {
-        return this.addIns.listType(type);
-      } catch (e) {
-        return [];
-      }
-    }                              
+
+    listAddIns: function(type, subType) {
+      var type = normalizeAddInKey(type, subType);
+      return this.addIns.tryListType(type) || [];
+    }
   });
-    
+
 });

--- a/cdf-core/cdf/js/Dashboards.AddIns.js
+++ b/cdf-core/cdf/js/Dashboards.AddIns.js
@@ -1,6 +1,6 @@
 /*!
  * Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
- * 
+ *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
  * this file except in compliance with the license. If you need a copy of the license,
@@ -18,56 +18,51 @@
 
 
 // ADDINS begin
-;(function (D){
-  D.addIns = new D.Container ();
+;(function(D) {
+  D.addIns = new D.Container();
 
-  //Normalization - Ensure component does not finish with component and capitalize first letter
+  // Normalization - Ensure component does not finish with component and capitalize first letter
+  var CompSuffix = 'Component';
+  var CompSuffixLen = CompSuffix.length;
+
   D.normalizeAddInKey = function(key, subKey) {
-      if (key.indexOf('Component', key.length - 'Component'.length) !== -1) 
-        key = key.substring(0, key.length - 'Component'.length);  
-      key = key.charAt(0).toUpperCase() + key.substring(1);
+    if(key.indexOf(CompSuffix, key.length - CompSuffixLen) !== -1)
+      key = key.substring(0, key.length - CompSuffixLen);
 
-      if(subKey) { key += "." + subKey; }
+    key = key.charAt(0).toUpperCase() + key.substring(1);
+
+    if(subKey) { key += "." + subKey; }
 
     return key;
-  }
+  };
 
-  D.registerAddIn = function(type,subType,addIn){
+  D.registerAddIn = function(type, subType, addIn) {
     var type = this.normalizeAddInKey(type, subType),
         name = addIn.getName ? addIn.getName() : null;
+
     this.addIns.register(type, name, addIn);
   };
 
-  D.hasAddIn = function(type,subType,addInName){
-    var type = this.normalizeAddInKey(type, subType);
-    return Boolean(this.addIns && this.addIns.has(type,addInName));
+  D.hasAddIn = function(type, subType, addInName) {
+    type = this.normalizeAddInKey(type, subType);
+    return this.addIns.has(type, addInName);
   };
 
-  D.getAddIn = function(type,subType,addInName){
-    var type = this.normalizeAddInKey(type, subType);
-    try {
-      var addIn = this.addIns.get(type,addInName);
-      return addIn;
-    } catch (e) {
-      return null;
-    }
+  D.getAddIn = function(type, subType, addInName) {
+    type = this.normalizeAddInKey(type, subType);
+    return this.addIns.tryGet(type, addInName);
   };
 
   D.setAddInDefaults = function(type, subType, addInName, defaults) {
-    var addIn = this.getAddIn(type, subType,addInName);
-    if(addIn) {
-      addIn.setDefaults(defaults);
-    }
+    var addIn = this.getAddIn(type, subType, addInName);
+    if(addIn) addIn.setDefaults(defaults);
   };
+
   D.listAddIns = function(type, subType) {
-  var type = this.normalizeAddInKey(type, subType);
-    var addInList = [];
-    try {
-      return this.addIns.listType(type);
-    } catch (e) {
-      return [];
-    }
+    type = this.normalizeAddInKey(type, subType);
+    return this.addIns.tryListType(type) || [];
   };
+
 })(Dashboards);
 // ADDINS end
 


### PR DESCRIPTION
- Alternate more powerful implementation.
  - No need to pre-specify allowed extension points.
  - If two mixing provide the same method, or a single mixing and the main method, then a coordination method is always generated.
  - Handles the special preExecution case.
  - Can handle any case by overriding conventionally named methods "_createMixinMethod_&lt;forMethodName&gt;".
- Cleanup of the "legacy" AddIns code.
- Passed the tests on the first write up! (doesn't mean it will actually work...)
- Placed some notes here and there, for things I think should be fixed.

@pamval please appreciate.
